### PR TITLE
Basic implementation

### DIFF
--- a/examples/ailerons.py
+++ b/examples/ailerons.py
@@ -1,0 +1,213 @@
+from torch.utils.data import Dataset
+import torch
+import kde
+import re
+import numpy as np
+from sklearn.neighbors import KernelDensity
+import matplotlib.pyplot as plt
+import time
+
+percentile_re = re.compile(r'(?:\[(\d+),\s{0,1}(\d+)\],{0,1})')
+
+class DatasetCommon():
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        original_init = cls.__init__
+        def new_init(self, *args, **kwargs):
+            original_init(self, *args, **kwargs)
+            self._apply_slice()
+            self._percentile_partition()
+            self._dtype_conversion()
+        cls.__init__ = new_init
+
+
+    def __len__(self):
+        return self.len
+
+    def to(self, device):
+        self.input = self.input.to(device)
+        self.output = self.output.to(device)
+        return self
+
+    @property
+    def len(self):
+        return len(self.input)
+
+    def __getitem__(self, idx):
+        return (self.input[idx],
+                self.output[idx])
+
+    def input_as_torch_tensor(self):
+        return self.input
+
+    def output_as_torch_tensor(self):
+        return self.output
+
+    def get_percentiles(self):
+        try:
+            percs = self.kwargs['percentiles']
+            parsed = percentile_re.findall(percs)
+            opt_percs = list()
+            for p in parsed:
+                lower, uper = int(p[0]), int(p[1])
+                opt_percs.append((lower, uper))
+            return opt_percs
+        except KeyError:
+            return [(0, 100)]
+
+
+    def percentile_partition(self, percentiles):
+        input_tensor = self.input_as_torch_tensor()
+        output_tensor = self.output_as_torch_tensor()
+
+        if len(output_tensor.shape) > 2:
+            return input_tensor, output_tensor
+        
+        unique_percentiles = sorted(set(p for range_pair in percentiles for p in range_pair))
+        percentile_values = torch.tensor([
+            torch.quantile(output_tensor, q/100) for q in unique_percentiles
+        ])
+        
+        percentile_dict = dict(zip(unique_percentiles, percentile_values))
+        
+        mask = torch.zeros(len(output_tensor), dtype=torch.bool)
+
+        for lower, upper in percentiles:
+            lower_value = percentile_dict[lower]
+            upper_value = percentile_dict[upper]
+            if lower == 0:
+                mask |= (output_tensor <= upper_value).view(len(output_tensor))
+            else:
+                mask |= ((output_tensor > lower_value) & (output_tensor <= upper_value)).view(len(output_tensor))
+        
+        partitioned_input = input_tensor[mask]
+        partitioned_output = output_tensor[mask]
+        
+        return partitioned_input, partitioned_output
+
+
+    def _percentile_partition(self):
+        self.input, self.output = self.percentile_partition(self.get_percentiles())
+
+    def _dtype_conversion(self):
+        try:
+            dt = self.kwargs['dtype']
+            self.input = self.input.type(dtype=getattr(torch, dt))
+            self.output = self.output.type(dtype=getattr(torch, dt))
+        except KeyError:
+            pass
+
+    def _apply_slice(self):
+        try:
+            subset = self.kwargs['subset']
+            if 'step' not in subset:
+                subset['step'] = 1
+            if 'start' not in subset:
+                subset['start'] = 0
+
+            start = subset['start']
+            stop = subset['stop']
+            step = subset['step']
+            slc = slice(start, stop, step)
+            self.input = self.input[slc]
+            self.output = self.output[slc]
+        except KeyError:
+            pass
+
+    @property
+    def dtype(self):
+        return self.input.dtype
+
+    def train_test_split(self, test_proportion: float):
+        test_size = int(len(self) * test_proportion)
+        train_size = len(self) - test_size
+        return torch.utils.data.random_split(self, [train_size, test_size])
+
+class ARFFDataSet(DatasetCommon, Dataset):
+    def __init__(self, path: str, **kwargs):
+        super().__init__(**kwargs)
+        self.path = path
+        self.input, self.output = self.read_arff_file(path)
+        self.input, self.output = torch.tensor(self.input), torch.tensor(self.output)
+
+    def read_arff_file(self, path):
+        from scipy.io import arff
+        import pandas as pd
+        data, meta = arff.loadarff(path)
+        df = pd.DataFrame(data)
+        return df.iloc[:, :-1].values, np.expand_dims(df.iloc[:, -1].values, -1)
+
+    @property
+    def shape(self):
+        return self.input.shape
+
+
+def main():
+    ailerons_path = '/scratch/mzu/zanef2/surrogates/SurrogateResults/2024-08-09_kde_new_datasets/ailerons.arff'
+    data = ARFFDataSet(ailerons_path)
+    print(data.input.shape)
+    print(data.output.shape)
+
+    id_tails_percentiles = [(0, 70)]
+    ood_tails_percentiles = [(70, 100)]
+    id_tails_data = data.percentile_partition(id_tails_percentiles)
+    ood_tails_data = data.percentile_partition(ood_tails_percentiles)
+
+    id_input, id_output = id_tails_data
+    ood_input, ood_output = ood_tails_data
+    id_input = id_input.to(torch.float32).to("cuda")
+    ood_input = ood_input.to(torch.float32).to("cuda")
+    id_output = id_output.to(torch.float32).to("cuda")
+    ood_output = ood_output.to(torch.float32).to("cuda")
+
+    gpu_kde = kde.KNNKDE(k=15, bandwidth='scott', kernel="gaussian")
+    gpu_kde.fit(id_input)
+    kde_sklearn = KernelDensity(bandwidth=0.2, kernel="gaussian", rtol=0.1)
+    kde_sklearn.fit(id_input.cpu().numpy())
+
+    # do some warmups for the jit
+    for _ in range(10):
+        kde_densities = gpu_kde.kernel_density(id_input)
+
+    start_time = time.time()
+    kde_densities = gpu_kde.kernel_density(id_input)
+    end_time = time.time()
+    print(f"KDE time: {end_time - start_time}")
+    kde_densities_ood = gpu_kde.kernel_density(ood_input)
+
+    id_input_cpu = id_input.cpu().numpy()
+    start_time = time.time()
+    kde_sklearn_densities = kde_sklearn.score_samples(id_input_cpu)
+    end_time = time.time()
+    print(f"Scipy time: {end_time - start_time}")
+    ood_input_cpu = ood_input.cpu().numpy()
+    kde_sklearn_densities_ood = kde_sklearn.score_samples(ood_input_cpu)
+
+    id_input = id_input.cpu().numpy()
+    ood_input = ood_input.cpu().numpy()
+    kde_densities = kde_densities.cpu().numpy()
+    kde_densities_ood = kde_densities_ood.cpu().numpy()
+    kde_sklearn_densities = kde_sklearn_densities
+    kde_sklearn_densities_ood = kde_sklearn_densities_ood
+    #normalize our densities to [0, 1] so they are on the same scale
+    # kde_densities and kde_densities_ood should be on the same scale
+    # kde_sklearn_densities and kde_sklearn_densities_ood should be on the same scale
+    # kde_densities = (kde_densities - np.min(kde_densities)) / (np.max(kde_densities) - np.min(kde_densities))
+    # kde_densities_ood = (kde_densities_ood - np.min(kde_densities_ood)) / (np.max(kde_densities) - np.min(kde_densities))
+    # kde_sklearn_densities = (kde_sklearn_densities - np.min(kde_sklearn_densities)) / (np.max(kde_sklearn_densities) - np.min(kde_sklearn_densities))
+    # kde_sklearn_densities_ood = (kde_sklearn_densities_ood - np.min(kde_sklearn_densities_ood)) / (np.max(kde_sklearn_densities) - np.min(kde_sklearn_densities))
+
+    # we need to do an eCDF of the kde_densities and the scipy_densities and plot them
+    plt.ecdf(kde_densities, label="KDE")
+    # plt.ecdf(kde_sklearn_densities, label="Scipy")
+    plt.ecdf(kde_densities_ood, label="KDE OOD")
+    # plt.ecdf(kde_sklearn_densities_ood, label="Scipy OOD")
+    plt.legend()
+    plt.savefig("densities.png")
+    plt.close()
+
+if __name__ == "__main__":
+    main()

--- a/examples/scipy_comparison.py
+++ b/examples/scipy_comparison.py
@@ -1,0 +1,46 @@
+from kde import KNNKDE
+import torch
+from sklearn.neighbors import KernelDensity
+import matplotlib.pyplot as plt
+import time
+
+
+def main():
+    data = torch.randn(500000, 10, device="cuda").to(torch.float32)
+    kde = KNNKDE(k=5, bandwidth=0.2, kernel="gaussian")
+    kde_sklearn = KernelDensity(bandwidth=0.2, kernel="gaussian", rtol=0.1)
+    data_cpu = data.cpu().numpy()
+    kde_sklearn.fit(data_cpu)
+    kde.fit(data)
+    for _ in range(10):
+        kde_densities = kde.kernel_density(data[0:20])
+
+    start = time.time()
+    knn_densities = kde.kernel_density(data)
+    end = time.time()
+
+    print(f"KDE time: {end - start}")
+    start = time.time()
+    scipy_densities = kde_sklearn.score_samples(data_cpu)
+    end = time.time()
+    print(f"Scipy time: {end - start}")
+
+    data = data.cpu().numpy()
+    knn_densities = knn_densities.cpu().numpy()
+
+    plt.scatter(data[:, 0], data[:, 1])
+    plt.savefig("data.png")
+    plt.close()
+
+    plt.scatter(data[:, 0], data[:, 1], c=knn_densities)
+    plt.savefig("knn_densities.png")
+    plt.close()
+
+    plt.scatter(data[:, 0], data[:, 1], c=scipy_densities)
+    plt.savefig("scipy_densities.png")
+    plt.close()
+
+
+
+if __name__ == "__main__":
+    main()

--- a/kde/__init__.py
+++ b/kde/__init__.py
@@ -1,0 +1,1 @@
+from .kde import KNNKDE

--- a/kde/kde.py
+++ b/kde/kde.py
@@ -1,0 +1,200 @@
+import faiss
+import numpy as np
+import torch
+from typing import Union
+from faiss.contrib import torch_utils
+import time
+
+TensorOrArray = Union[torch.Tensor, np.ndarray]
+
+
+@torch.jit.script
+def _gaussian_kernel(x: torch.Tensor, y: torch.Tensor, bandwidth: torch.Tensor) -> torch.Tensor:
+    """Compute the Gaussian kernel between points x and their k-nearest neighbors y.
+
+    Args:
+        x (torch.Tensor): Input points of shape [batch_size, features]
+        y (torch.Tensor): K-nearest neighbors of shape [batch_size, k, features]
+        bandwidth (torch.Tensor): Kernel bandwidth for each dimension of shape [features]
+
+    Returns:
+        torch.Tensor: Kernel values of shape [batch_size, k]
+    """
+    batch_size, k, features = y.shape
+    
+    # Reshape x to [batch_size, 1, features] to broadcast with y
+    x_expanded = x.unsqueeze(1)
+    
+    diff = x_expanded - y
+    # Reshape bandwidth to [1, 1, features] for broadcasting
+    bandwidth_expanded = bandwidth.view(1, 1, -1)
+    squared_distances = torch.sum((diff / bandwidth_expanded) * (diff / bandwidth_expanded), dim=2)
+    
+    # Compute kernel values (no need to square bandwidth since we already divided by it)
+    exponent = -0.5 * squared_distances
+    
+    return torch.exp(exponent)
+
+@torch.jit.script
+def _scaler_transform(x: torch.Tensor, mean: torch.Tensor, std: torch.Tensor) -> torch.Tensor:
+    """Transform features by standardizing to zero mean and unit variance.
+
+    Args:
+        x (torch.Tensor): Input tensor to transform
+        mean (torch.Tensor): Mean of each feature
+        std (torch.Tensor): Standard deviation of each feature
+
+    Returns:
+        torch.Tensor: Transformed tensor with zero mean and unit variance
+    """
+    return (x - mean) / std
+
+class StandardScaler:
+    """Standardize features by removing the mean and scaling to unit variance.
+    
+    Similar to sklearn's StandardScaler, but implemented for PyTorch tensors.
+    """
+
+    def __init__(self):
+        self.mean = None
+        self.std = None
+
+    def fit(self, X):
+        """Compute the mean and std to be used for later scaling.
+
+        Args:
+            X (torch.Tensor): Training data to compute mean and std from
+        """
+        self.mean = X.mean(dim=0)
+        self.std = X.std(dim=0)
+        self.std = torch.clamp(self.std, min=1e-6)
+
+    def transform(self, X):
+        """Perform standardization by centering and scaling.
+
+        Args:
+            X (torch.Tensor): Data to transform
+
+        Returns:
+            torch.Tensor: Standardized data
+        """
+        return _scaler_transform(X, self.mean, self.std)
+
+class KNNKDE:
+    """
+    K-Nearest Neighbors Kernel Density Estimation.
+    Uses FAISS for efficient nearest neighbor search.
+    L2 distance is used for the distance metric.
+
+    Parameters:
+        k: int, number of neighbors
+        bandwidth: float, str, or torch.Tensor
+            If float: uses the same bandwidth for all dimensions
+            If 'scott': uses Scott's rule with dimension correction
+            If torch.Tensor: uses different bandwidth for each dimension
+        kernel: str, kernel type (only 'gaussian' supported)
+    """
+    def __init__(self, k=5, bandwidth=1.0, kernel="gaussian"):
+        self.k = k
+        self.bandwidth_spec = bandwidth  # Store the specification
+        self.bandwidth = None  # Will be set during fit
+        assert kernel.lower() == "gaussian", "Only Gaussian kernel is supported"
+        self.kernel = kernel
+        self.index = None
+        self.gpu_available = faiss.get_num_gpus() > 0
+        self.scaler = StandardScaler()
+
+    def _compute_scott_bandwidth(self, n_samples: int, n_features: int, std: torch.Tensor) -> torch.Tensor:
+        """Compute Scott's rule bandwidth with high-dimensional correction.
+
+        Args:
+            n_samples (int): Number of samples in the dataset
+            n_features (int): Number of features/dimensions
+            std (torch.Tensor): Standard deviation of each feature
+
+        Returns:
+            torch.Tensor: Computed bandwidth for each dimension
+        """
+        # Basic Scott's rule
+        scott_factor = n_samples ** (-1.0 / (n_features + 4))
+        
+        # Apply dimension correction: as dimensions increase, we slow down the 
+        # bandwidth decrease to prevent undersmoothing
+        dim_correction = max(1.0, np.log10(n_features))
+        corrected_bandwidth = std * scott_factor * dim_correction
+        
+        # Add safety clipping to prevent extreme values
+        return torch.clamp(corrected_bandwidth, min=1e-3, max=100.0)
+
+    def _set_bandwidth(self, X: torch.Tensor) -> None:
+        """Set the kernel bandwidth based on the specification and input data.
+
+        Args:
+            X (torch.Tensor): Input data tensor of shape [n_samples, n_features]
+        
+        Raises:
+            ValueError: If bandwidth specification is invalid
+        """
+        n_samples, n_features = X.shape
+        device = X.device
+
+        if isinstance(self.bandwidth_spec, str) and self.bandwidth_spec.lower() == 'scott':
+            self.bandwidth = self._compute_scott_bandwidth(
+                n_samples, 
+                n_features, 
+                self.scaler.std
+            ).to(device)
+        elif isinstance(self.bandwidth_spec, (int, float)):
+            # Use same bandwidth for all dimensions
+            self.bandwidth = torch.full(
+                (n_features,), 
+                float(self.bandwidth_spec),
+                device=device
+            )
+        elif isinstance(self.bandwidth_spec, torch.Tensor):
+            assert len(self.bandwidth_spec) == n_features, \
+                f"Bandwidth tensor must have {n_features} elements"
+            self.bandwidth = self.bandwidth_spec.to(device)
+        else:
+            raise ValueError(
+                "bandwidth must be 'scott', a number, or a tensor"
+            )
+
+    def fit(self, X):
+        """Fit the KNN-KDE model to the input data.
+
+        This method:
+        1. Fits the standard scaler
+        2. Sets the bandwidth
+        3. Builds the FAISS index for efficient nearest neighbor search
+
+        Args:
+            X (torch.Tensor): Training data of shape [n_samples, n_features]
+        """
+        self.scaler.fit(X)
+        X_scaled = self.scaler.transform(X)
+        
+        # Set bandwidth based on specification
+        self._set_bandwidth(X)
+
+        if self.gpu_available:
+            self.index = faiss.index_cpu_to_all_gpus(faiss.IndexFlatL2(X_scaled.shape[1]))
+        else:
+            self.index = faiss.IndexFlatL2(X_scaled.shape[1])
+        self.index.add(X_scaled)
+
+    
+    def kernel_density(self, x):
+        """Estimate the probability density at the given points.
+
+        Args:
+            x (torch.Tensor): Points to estimate density at, shape [batch_size, features]
+
+        Returns:
+            torch.Tensor: Estimated density values of shape [batch_size]
+        """
+        # x can now be [batch_size, features]
+        x = self.scaler.transform(x)
+        D, I, R = self.index.search_and_reconstruct(x, k=self.k)
+        kernel_values = _gaussian_kernel(x, R, self.bandwidth)
+        return torch.mean(kernel_values, dim=1)  # Average over k neighbors for each sample

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[build-system]
+requires = ["hatchling"]
+
+build-backend = "hatchling.build"
+
+[project]
+name = "kde"
+version = "0.1.0"
+dependencies = ["click", 
+                "pytest",
+                "pandas",
+                "numpy<2",
+                ]
+requires-python = ">= 3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,15 @@ build-backend = "hatchling.build"
 [project]
 name = "kde"
 version = "0.1.0"
-dependencies = ["click", 
-                "pytest",
-                "pandas",
-                "numpy<2",
-                ]
+dependencies = [
+    "click",
+    "pytest",
+    "pandas",
+    "numpy<2",
+    "torch",
+    "faiss-gpu",
+    "scikit-learn",
+    "matplotlib",
+    "scipy",
+]
 requires-python = ">= 3.8"


### PR DESCRIPTION
Adds an implementation of GPU-based Kernel Density Estimation that uses FAISS to avoid long-range density calculations. Allows constant bandwidth use and per-dimension Scott bandwidth estimation. Uses standard scaling for simple bandwidth scaling constants instead of covariance-based scaling. Demonstrates roughly 100x speedup over Scikit-learn's implementation.